### PR TITLE
Fixed TypeError when retraining

### DIFF
--- a/deep_q_network.py
+++ b/deep_q_network.py
@@ -150,7 +150,7 @@ def trainNetwork(s, readout, h_fc1, sess):
         # only train if done observing
         if t > OBSERVE:
             # sample a minibatch to train on
-            minibatch = random.sample(D, BATCH)
+            minibatch = random.sample(list(D), BATCH)
 
             # get the batch variables
             s_j_batch = [d[0] for d in minibatch]


### PR DESCRIPTION
The error 'TypeError: Population must be a sequence or set.  For dicts, use list(d)' sometimes occurred, so I made this small fix for next users who might play with it.
